### PR TITLE
Improv 0.5.1

### DIFF
--- a/sanic_routing/__init__.py
+++ b/sanic_routing/__init__.py
@@ -1,5 +1,5 @@
 from .route import Route
 from .router import BaseRouter
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 __all__ = ("BaseRouter", "Route")

--- a/sanic_routing/router.py
+++ b/sanic_routing/router.py
@@ -249,7 +249,10 @@ class BaseRouter(ABC):
                         Line("basket['__params__'] = match.groupdict()", 2),
                         Line(f"basket['__raw_path__'] = '{route.path}'", 2),
                         Line(
-                            f"return router.name_index['{route.name}'], basket",
+                            (
+                                f"return router.name_index['{route.name}'], "
+                                "basket"
+                            ),
                             2,
                         ),
                     ]

--- a/sanic_routing/router.py
+++ b/sanic_routing/router.py
@@ -234,9 +234,6 @@ class BaseRouter(ABC):
             src += self.tree.render()
 
         if self.regex_routes:
-            # TODO:
-            # - we should probably pre-compile the patterns and only
-            #   include them here by reference
             routes = sorted(
                 self.regex_routes.values(),
                 key=lambda route: len(route.parts),

--- a/sanic_routing/router.py
+++ b/sanic_routing/router.py
@@ -1,6 +1,5 @@
 import typing as t
 from abc import ABC, abstractmethod
-from itertools import count
 from types import SimpleNamespace
 
 from .exceptions import BadMethod, FinalizationError, NoMethod, NotFound
@@ -18,8 +17,6 @@ from urllib.parse import unquote  # noqa  isort:skip
 from uuid import UUID  # noqa  isort:skip
 from .patterns import parse_date  # noqa  isort:skip
 
-TMP = count()
-
 
 class BaseRouter(ABC):
     DEFAULT_METHOD = "BASE"
@@ -32,8 +29,10 @@ class BaseRouter(ABC):
         method_handler_exception: t.Type[NoMethod] = NoMethod,
         route_class: t.Type[Route] = Route,
         stacking: bool = False,
+        cascade_not_found: bool = False,
     ) -> None:
         self._find_route = None
+        self._matchers = None
         self.static_routes: t.Dict[t.Tuple[str, ...], Route] = {}
         self.dynamic_routes: t.Dict[t.Tuple[str, ...], Route] = {}
         self.regex_routes: t.Dict[t.Tuple[str, ...], Route] = {}
@@ -46,6 +45,7 @@ class BaseRouter(ABC):
         self.finalized = False
         self.stacking = stacking
         self.ctx = SimpleNamespace()
+        self.cascade_not_found = cascade_not_found
 
     @abstractmethod
     def get(self, **kwargs):
@@ -201,6 +201,7 @@ class BaseRouter(ABC):
             Line("def find_route(path, router, basket, extra):", 0),
             Line("parts = tuple(path[1:].split(router.delimiter))", 1),
         ]
+        delayed = []
 
         if self.static_routes:
             # TODO:
@@ -236,21 +237,30 @@ class BaseRouter(ABC):
             # TODO:
             # - we should probably pre-compile the patterns and only
             #   include them here by reference
-            src += [
-                line
-                for route in self.regex_routes.values()
-                for line in [
-                    Line(f"match = re.match(r'^{route.pattern}$', path)", 1),
-                    Line("if match:", 1),
-                    Line("basket['__params__'] = match.groupdict()", 2),
-                    Line(f"basket['__raw_path__'] = '{route.path}'", 2),
-                    Line(
-                        f"return router.name_index['{route.name}'], basket", 2
-                    ),
-                ]
-            ]
+            routes = sorted(
+                self.regex_routes.values(),
+                key=lambda route: len(route.parts),
+                reverse=True,
+            )
+            delayed.append(Line("matchers = [", 0))
+            for idx, route in enumerate(routes):
+                delayed.append(Line(f"re.compile(r'^{route.pattern}$'),", 1))
+                src.extend(
+                    [
+                        Line(f"match = router.matchers[{idx}].match(path)", 1),
+                        Line("if match:", 1),
+                        Line("basket['__params__'] = match.groupdict()", 2),
+                        Line(f"basket['__raw_path__'] = '{route.path}'", 2),
+                        Line(
+                            f"return router.name_index['{route.name}'], basket",
+                            2,
+                        ),
+                    ]
+                )
+            delayed.append(Line("]", 0))
 
         src.append(Line("raise NotFound", 1))
+        src.extend(delayed)
 
         self.optimize(src)
 
@@ -276,10 +286,15 @@ class BaseRouter(ABC):
             ctx: t.Dict[t.Any, t.Any] = {}
             exec(compiled_src, None, ctx)
             self._find_route = ctx["find_route"]
+            self._matchers = ctx.get("matchers")
 
     @property
     def find_route(self):
         return self._find_route
+
+    @property
+    def matchers(self):
+        return self._matchers
 
     @property
     def routes(self):
@@ -289,8 +304,7 @@ class BaseRouter(ABC):
             **self.regex_routes,
         }
 
-    @staticmethod
-    def optimize(src: t.List[Line]) -> None:
+    def optimize(self, src: t.List[Line]) -> None:
         """
         Insert NotFound exceptions to be able to bail as quick as possible,
         and realign lines to proper indentation
@@ -330,10 +344,11 @@ class BaseRouter(ABC):
             insert_at.add((len(src), idnt))
             idnt += 1
 
-        for num, indent in sorted(insert_at, key=lambda x: (x[0] * -1, x[1])):
-
-            next(TMP)
-            src.insert(num, Line("raise NotFound", indent))
+        if self.cascade_not_found:
+            for num, indent in sorted(
+                insert_at, key=lambda x: (x[0] * -1, x[1])
+            ):
+                src.insert(num, Line("raise NotFound", indent))
 
     def _is_regex(self, path: str):
         parts = path_to_parts(path, self.delimiter)

--- a/tests/test_router_source.py
+++ b/tests/test_router_source.py
@@ -1,0 +1,27 @@
+import pytest
+from sanic_routing import BaseRouter
+
+
+class Router(BaseRouter):
+    def get(self, path, method):
+        return self.resolve(path=path, method=method)
+
+
+@pytest.mark.parametrize(
+    "cascade,lines,not_founds",
+    (
+        (True, 32, 6),
+        (False, 30, 4),
+    ),
+)
+def test_route_correct_coercion(cascade, lines, not_founds):
+    def handler():
+        ...
+
+    router = Router(cascade_not_found=cascade)
+    router.add("/<one>", handler)
+    router.add("/<one>/two/three", handler)
+
+    router.finalize()
+    assert router.find_route_src.count("\n") == lines
+    assert router.find_route_src.count("raise NotFound") == not_founds

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -293,7 +293,6 @@ def test_route_correct_coercion():
     router.add("/<test:ymd>", handler4)
 
     router.finalize()
-    print(router.find_route_src)
 
     _, h1, __ = router.get("/foo", "BASE")
     _, h2, __ = router.get("/123", "BASE")

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -2,7 +2,6 @@ import uuid
 from datetime import date
 
 import pytest
-
 from sanic_routing import BaseRouter
 from sanic_routing.exceptions import NoMethod, NotFound, RouteExists
 
@@ -272,3 +271,36 @@ def test_use_route_type_coercion_deeper(handler):
         router.get("/test/123/bar/bbbb", "BASE")
     with pytest.raises(NotFound):
         router.get("/test/123/bar/bbbb/cccc", "BASE")
+
+
+def test_route_correct_coercion():
+    def handler1():
+        ...
+
+    def handler2():
+        ...
+
+    def handler3():
+        ...
+
+    def handler4():
+        ...
+
+    router = Router()
+    router.add("/<test:string>", handler1)
+    router.add("/<test:int>", handler2)
+    router.add("/<test:uuid>", handler3)
+    router.add("/<test:ymd>", handler4)
+
+    router.finalize()
+    print(router.find_route_src)
+
+    _, h1, __ = router.get("/foo", "BASE")
+    _, h2, __ = router.get("/123", "BASE")
+    _, h3, __ = router.get("/726a7d33-4bd5-46a3-a02d-37da7b4b029b", "BASE")
+    _, h4, __ = router.get("/2021-03-21", "BASE")
+
+    assert h1 is handler1
+    assert h2 is handler2
+    assert h3 is handler3
+    assert h4 is handler4


### PR DESCRIPTION
This adds a few tweaks I have noticed that are helpful with larger APIs.

- One of the "performance" features is trying to bail out and raise a `NotFound` as early as possible. This logic needs a better review on larger APIs, so I am defaulting it to off for now. But, it could be added like this:
    ```python
    from sanic.router import Router

    app = Sanic(__name__, router=Router(cascade_not_found=True)
    ```
- Regular expression matching is sorted by length. It previously had none and being based upon `set()` was not consistent. Therefore, especially pattern matching on `path`, results were inconsistent. I am not sure of the best way to test this since it is a transient error, but I have done extensive testing locally to make sure it resolved properly.
- Pre-compile regex routes for faster matching. As we all know, `re` is way faster when you do not need to compile at the operation.