### PR TITLE
Add NotFound to help situation when need to raise for non-strict routes

### DIFF
--- a/sanic_routing/__init__.py
+++ b/sanic_routing/__init__.py
@@ -1,5 +1,5 @@
 from .route import Route
 from .router import BaseRouter
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 __all__ = ("BaseRouter", "Route")

--- a/sanic_routing/tree.py
+++ b/sanic_routing/tree.py
@@ -78,6 +78,7 @@ class Node:
 
         level = self.level - 1
         equality_check = False
+        len_check = ""
         return_bump = 1
 
         if self.first or self.root:
@@ -164,9 +165,14 @@ class Node:
                     # Line("...", return_indent - 1, render=True),
                 ]
             )
-            if self.route.params:
+
+            if self.route.params or self.route.requirements:
                 location.append(Line("...", return_indent - 1, render=False))
                 if self.last:
+                    if len_check:
+                        location.append(
+                            Line("raise NotFound", return_indent - 1)
+                        )
                     location.append(
                         Line("...", return_indent - 2, render=False),
                     )

--- a/sanic_routing/tree.py
+++ b/sanic_routing/tree.py
@@ -166,13 +166,12 @@ class Node:
                 ]
             )
 
-            if self.route.params or self.route.requirements:
+            if self.route.requirements and self.last and len_check:
+                location.append(Line("raise NotFound", return_indent - 1))
+
+            if self.route.params:
                 location.append(Line("...", return_indent - 1, render=False))
                 if self.last:
-                    if len_check:
-                        location.append(
-                            Line("raise NotFound", return_indent - 1)
-                        )
                     location.append(
                         Line("...", return_indent - 2, render=False),
                     )

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -339,3 +339,33 @@ def test_non_strict_bail_out():
 
     _, handler, __ = router.get("/test/ing/", "BASE", extra={"req": "bar"})
     assert handler() == "handler3"
+
+
+def test_non_strict_with_params():
+    def handler1():
+        return "handler1"
+
+    def handler2():
+        return "handler2"
+
+    router = Router()
+    router.add("/<foo>", handler1)
+    router.add("/<foo>/ing", handler2)
+
+    router.finalize()
+
+    _, handler, params = router.get("/test", "BASE")
+    assert handler() == "handler1"
+    assert params == {"foo": "test"}
+
+    _, handler, params = router.get("/test/", "BASE")
+    assert handler() == "handler1"
+    assert params == {"foo": "test"}
+
+    _, handler, params = router.get("/test/ing", "BASE")
+    assert handler() == "handler2"
+    assert params == {"foo": "test"}
+
+    _, handler, params = router.get("/test/ing/", "BASE")
+    assert handler() == "handler2"
+    assert params == {"foo": "test"}


### PR DESCRIPTION
Failed tests here: https://github.com/sanic-org/sanic/pull/2100/checks?check_run_id=2274096036

The reason was that #21 removed the cascading. There actually was a need for that in some circumstances. Mainly when there is a match on a route that otherwise is being evaluated with `==` and it was passed with `/`. Strict slashes is a bear for support and complexity.

```python
def find_route(path, router, basket, extra):
    parts = tuple(path[1:].split(router.delimiter))
    num = len(parts)
    if num > 0:
        if parts[0] == "test":
            if num > 1:
                if parts[1] == "other" and num == 2:
                    if extra == {'host': 'sub1.example.com'}:
                        basket['__handler_idx__'] = 0
                    elif extra == {'host': 'sub2.example.com'}:
                        basket['__handler_idx__'] = 1
                    else:
                        raise NotFound
                    basket['__raw_path__'] = 'test/other'
                    return router.dynamic_routes[('test', 'other')], basket
                raise NotFound    # <<< WAS MISSING
            if extra == {'host': 'example.com'}:
                basket['__handler_idx__'] = 0
            elif extra == {'host': 'sub.example.com'}:
                basket['__handler_idx__'] = 1
            elif extra == {'host': 'sub1.example.com'}:
                basket['__handler_idx__'] = 2
            elif extra == {'host': 'sub2.example.com'}:
                basket['__handler_idx__'] = 3
            else:
                raise NotFound
            basket['__raw_path__'] = 'test'
            return router.dynamic_routes[('test',)], basket
    raise NotFound
```