### PR TITLE
Route group

### DIFF
--- a/sanic_routing/__init__.py
+++ b/sanic_routing/__init__.py
@@ -1,5 +1,5 @@
-from .route import Route
 from .group import RouteGroup
+from .route import Route
 from .router import BaseRouter
 
 __version__ = "0.6.0"

--- a/sanic_routing/__init__.py
+++ b/sanic_routing/__init__.py
@@ -1,5 +1,6 @@
 from .route import Route
+from .group import RouteGroup
 from .router import BaseRouter
 
-__version__ = "0.5.2"
-__all__ = ("BaseRouter", "Route")
+__version__ = "0.6.0"
+__all__ = ("BaseRouter", "Route", "RouteGroup")

--- a/sanic_routing/exceptions.py
+++ b/sanic_routing/exceptions.py
@@ -22,7 +22,7 @@ class BadMethod(BaseException):
 class NoMethod(BaseException):
     def __init__(
         self,
-        message: str,
+        message: str = "Method does not exist",
         method: Optional[str] = None,
         allowed_methods: Optional[Set[str]] = None,
     ):

--- a/sanic_routing/group.py
+++ b/sanic_routing/group.py
@@ -45,7 +45,7 @@ class RouteGroup:
     def reset(self):
         self.methods_index = dict(self.methods_index)
 
-    def merge(self, group, overwrite: bool = False):
+    def merge(self, group, overwrite: bool = False, append: bool = False):
         _routes = list(self._routes)
         for other_route in group.routes:
             for current_route in self:
@@ -59,7 +59,7 @@ class RouteGroup:
                         not current_route.requirements
                         and other_route.requirements
                     )
-                ):
+                ) and not append:
                     if not overwrite:
                         raise RouteExists(
                             f"Route already registered: {self.raw_path} "

--- a/sanic_routing/group.py
+++ b/sanic_routing/group.py
@@ -8,12 +8,10 @@ class RouteGroup:
 
     def __init__(self, *routes) -> None:
         if len(set(route.parts for route in routes)) > 1:
-            raise InvalidUsage("Cannout group routes with differing paths")
+            raise InvalidUsage("Cannot group routes with differing paths")
 
         if any(routes[-1].strict != route.strict for route in routes):
-            raise InvalidUsage(
-                "Cannout group routes with differing strictness"
-            )
+            raise InvalidUsage("Cannot group routes with differing strictness")
 
         route_list = list(routes)
         route_list.pop()

--- a/sanic_routing/group.py
+++ b/sanic_routing/group.py
@@ -1,0 +1,103 @@
+from .exceptions import InvalidUsage, RouteExists
+
+
+class RouteGroup:
+    def __init__(self, *routes) -> None:
+        if len(set(route.parts for route in routes)) > 1:
+            raise InvalidUsage("Cannout group routes with differing paths")
+
+        if any(routes[-1].strict != route.strict for route in routes):
+            raise InvalidUsage(
+                "Cannout group routes with differing strictness"
+            )
+
+        route_list = list(routes)
+        route_list.pop()
+
+        self._routes = routes
+        self._method_index = {
+            method: route
+            for route in route_list
+            for method in route.defined_methods
+        }
+        self.pattern_idx = 0
+
+    def __str__(self):
+        display = (
+            f"path={self.path or self.router.delimiter} len={len(self.routes)}"
+        )
+        return f"<{self.__class__.__name__}: {display}>"
+
+    def __iter__(self):
+        return iter(self.routes)
+
+    def __getitem__(self, key):
+        return self.routes[key]
+
+    def merge(self, group, overwrite: bool = False):
+        _routes = list(self._routes)
+        for other_route in group.routes:
+            for current_route in self:
+                if current_route == other_route:
+                    if not overwrite:
+                        raise RouteExists(
+                            f"Route already registered: {self.raw_path} "
+                            f"[{','.join(self.methods)}]"
+                        )
+                else:
+                    _routes.append(other_route)
+        self._routes = tuple(_routes)
+
+    @property
+    def labels(self):
+        return self[0].labels
+
+    @property
+    def methods(self):
+        return frozenset(
+            [method for route in self for method in route.methods]
+        )
+
+    @property
+    def params(self):
+        return self[0].params
+
+    @property
+    def parts(self):
+        return self[0].parts
+
+    @property
+    def path(self):
+        return self[0].path
+
+    @property
+    def pattern(self):
+        return self[0].pattern
+
+    @property
+    def raw_path(self):
+        return self[0].raw_path
+
+    @property
+    def regex(self):
+        return self[0].regex
+
+    @property
+    def requirements(self):
+        return [route.requirements for route in self if route.requirements]
+
+    @property
+    def routes(self):
+        return self._routes
+
+    @property
+    def router(self):
+        return self[0].router
+
+    @property
+    def strict(self):
+        return self[0].strict
+
+    @property
+    def unquote(self):
+        return self[0].unquote

--- a/sanic_routing/route.py
+++ b/sanic_routing/route.py
@@ -152,17 +152,6 @@ class Route:
             sorted(params.items(), key=lambda param: self._sorting(param[1]))
         )
 
-    # def _finalize_methods(self):
-    #     self.methods = set()
-    #     for handlers in self.handlers.values():
-    #         self.methods.update(set(key.upper() for key in handlers.keys()))
-
-    # def _finalize_handlers(self):
-    #     self.handlers = Immutable(self.handlers)
-
-    # def _reset_handlers(self):
-    #     self.handlers = dict(self.handlers)
-
     def _compile_regex(self):
         components = []
 
@@ -204,8 +193,6 @@ class Route:
         self._finalize_params()
         if self.regex:
             self._compile_regex()
-        # self._finalize_methods()
-        # self._finalize_handlers()
 
     def reset(self):
         self._reset_handlers()

--- a/sanic_routing/route.py
+++ b/sanic_routing/route.py
@@ -118,33 +118,6 @@ class Route:
                             idx, part[1:-1], key_path, "string", str, None
                         )
 
-    def add_handler(
-        self,
-        raw_path,
-        handler,
-        method,
-        requirements,
-        overwrite: bool = False,
-    ):
-        ...
-        # key_path = parts_to_path(
-        #     path_to_parts(raw_path, self.router.delimiter),
-        #     self.router.delimiter,
-        # )
-
-        # if (
-        #     not self.router.stacking
-        #     and self.handlers.get(key_path, {}).get(method)
-        #     and (
-        #         requirements is None
-        #         or Requirements(requirements) in self.requirements.values()
-        #     )
-        #     and not overwrite
-        # ):
-        #     raise RouteExists(
-        #         f"Route already registered: {key_path} [{method}]"
-        #     )
-
     def add_parameter(
         self,
         idx: int,

--- a/sanic_routing/route.py
+++ b/sanic_routing/route.py
@@ -88,10 +88,17 @@ class Route:
     def __eq__(self, other) -> bool:
         if not isinstance(other, self.__class__):
             return False
-        return (self.parts, self.requirements,) == (
-            other.parts,
-            other.requirements,
-        ) and (self.methods & other.methods)
+        return bool(
+            (
+                self.parts,
+                self.requirements,
+            )
+            == (
+                other.parts,
+                other.requirements,
+            )
+            and (self.methods & other.methods)
+        )
 
     def _setup_params(self):
         key_path = parts_to_path(

--- a/sanic_routing/route.py
+++ b/sanic_routing/route.py
@@ -1,9 +1,9 @@
 import re
 import typing as t
-from collections import defaultdict, namedtuple
+from collections import namedtuple
 from types import SimpleNamespace
 
-from .exceptions import InvalidUsage, ParameterNameConflicts, RouteExists
+from .exceptions import InvalidUsage, ParameterNameConflicts
 from .patterns import REGEX_TYPES
 from .utils import Immutable, parts_to_path, path_to_parts
 
@@ -12,7 +12,7 @@ ParamInfo = namedtuple(
 )
 
 
-class Requirements(dict):
+class Requirements(Immutable):
     def __hash__(self):
         return hash(frozenset(self.items()))
 

--- a/sanic_routing/route.py
+++ b/sanic_routing/route.py
@@ -22,10 +22,11 @@ class Route:
         "_params",
         "_raw_path",
         "ctx",
-        "handlers",
+        "handler",
         "labels",
         "methods",
         "name",
+        "overloaded",
         "params",
         "parts",
         "path",
@@ -36,7 +37,6 @@ class Route:
         "static",
         "strict",
         "unquote",
-        "overloaded",
     )
 
     def __init__(
@@ -44,6 +44,9 @@ class Route:
         router,
         raw_path: str,
         name: str,
+        handler: t.Callable[..., t.Any],
+        methods: t.Iterable[str],
+        requirements: t.Dict[str, t.Any] = None,
         strict: bool = False,
         unquote: bool = False,
         static: bool = False,
@@ -52,10 +55,14 @@ class Route:
     ):
         self.router = router
         self.name = name
-        self.handlers = defaultdict(lambda: defaultdict(list))  # type: ignore
+        self.handler = handler
+        self.methods = methods
+        self.requirements = Requirements(requirements or {})
+
+        self.ctx = SimpleNamespace()
+
         self._params: t.Dict[int, ParamInfo] = {}
         self._raw_path = raw_path
-        self.ctx = SimpleNamespace()
 
         parts = path_to_parts(raw_path, self.router.delimiter)
         self.path = parts_to_path(parts, delimiter=self.router.delimiter)
@@ -66,8 +73,9 @@ class Route:
         self.pattern = None
         self.strict: bool = strict
         self.unquote: bool = unquote
-        self.requirements: t.Dict[int, t.Any] = {}
         self.labels: t.Optional[t.List[str]] = None
+
+        self._setup_params()
 
     def __repr__(self):
         display = (
@@ -77,53 +85,24 @@ class Route:
         )
         return f"<{self.__class__.__name__}: {display}>"
 
-    def get_handler(self, raw_path, method, idx):
-        method = method or self.router.DEFAULT_METHOD
-        raw_path = raw_path.lstrip(self.router.delimiter)
-        try:
-            return self.handlers[raw_path][method][idx]
-        except (IndexError, KeyError):
-            raise self.router.method_handler_exception(
-                f"Method '{method}' not found on {self}",
-                method=method,
-                allowed_methods=self.methods,
-            )
-
-    def add_handler(
-        self,
-        raw_path,
-        handler,
-        method,
-        requirements,
-        overwrite: bool = False,
-    ):
-        key_path = parts_to_path(
-            path_to_parts(raw_path, self.router.delimiter),
-            self.router.delimiter,
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, self.__class__):
+            return False
+        return (self.parts, self.requirements, self.methods,) == (
+            other.parts,
+            other.requirements,
+            other.methods,
         )
 
-        if (
-            not self.router.stacking
-            and self.handlers.get(key_path, {}).get(method)
-            and (
-                requirements is None
-                or Requirements(requirements) in self.requirements.values()
-            )
-            and not overwrite
-        ):
-            raise RouteExists(
-                f"Route already registered: {key_path} [{method}]"
-            )
-
-        idx = len(self.handlers[key_path][method.upper()])
-        self.handlers[key_path][method.upper()].append(handler)
-        if requirements is not None:
-            self.requirements[idx] = Requirements(requirements)
-
+    def _setup_params(self):
+        key_path = parts_to_path(
+            path_to_parts(self.raw_path, self.router.delimiter),
+            self.router.delimiter,
+        )
         if not self.static:
             parts = path_to_parts(key_path, self.router.delimiter)
             for idx, part in enumerate(parts):
-                if "<" in part and len(self.handlers[key_path]) == 1:
+                if "<" in part:
                     if ":" in part:
                         (
                             name,
@@ -138,6 +117,33 @@ class Route:
                         self.add_parameter(
                             idx, part[1:-1], key_path, "string", str, None
                         )
+
+    def add_handler(
+        self,
+        raw_path,
+        handler,
+        method,
+        requirements,
+        overwrite: bool = False,
+    ):
+        ...
+        # key_path = parts_to_path(
+        #     path_to_parts(raw_path, self.router.delimiter),
+        #     self.router.delimiter,
+        # )
+
+        # if (
+        #     not self.router.stacking
+        #     and self.handlers.get(key_path, {}).get(method)
+        #     and (
+        #         requirements is None
+        #         or Requirements(requirements) in self.requirements.values()
+        #     )
+        #     and not overwrite
+        # ):
+        #     raise RouteExists(
+        #         f"Route already registered: {key_path} [{method}]"
+        #     )
 
     def add_parameter(
         self,
@@ -173,16 +179,16 @@ class Route:
             sorted(params.items(), key=lambda param: self._sorting(param[1]))
         )
 
-    def _finalize_methods(self):
-        self.methods = set()
-        for handlers in self.handlers.values():
-            self.methods.update(set(key.upper() for key in handlers.keys()))
+    # def _finalize_methods(self):
+    #     self.methods = set()
+    #     for handlers in self.handlers.values():
+    #         self.methods.update(set(key.upper() for key in handlers.keys()))
 
-    def _finalize_handlers(self):
-        self.handlers = Immutable(self.handlers)
+    # def _finalize_handlers(self):
+    #     self.handlers = Immutable(self.handlers)
 
-    def _reset_handlers(self):
-        self.handlers = dict(self.handlers)
+    # def _reset_handlers(self):
+    #     self.handlers = dict(self.handlers)
 
     def _compile_regex(self):
         components = []
@@ -225,11 +231,15 @@ class Route:
         self._finalize_params()
         if self.regex:
             self._compile_regex()
-        self._finalize_methods()
-        self._finalize_handlers()
+        # self._finalize_methods()
+        # self._finalize_handlers()
 
     def reset(self):
         self._reset_handlers()
+
+    @property
+    def defined_params(self):
+        return self._params
 
     @property
     def raw_path(self):

--- a/sanic_routing/route.py
+++ b/sanic_routing/route.py
@@ -77,7 +77,7 @@ class Route:
 
         self._setup_params()
 
-    def __repr__(self):
+    def __str__(self):
         display = (
             f"name={self.name} path={self.path or self.router.delimiter}"
             if self.name and self.name != self.path

--- a/sanic_routing/router.py
+++ b/sanic_routing/router.py
@@ -166,7 +166,6 @@ class BaseRouter(ABC):
         if not static and route.parts in self.static_routes:
             existing_group = self.static_routes.pop(route.parts)
             group.merge(existing_group, overwrite)
-            # self.dynamic_routes[route.parts] = route
 
         else:
             if route.parts in routes:

--- a/sanic_routing/router.py
+++ b/sanic_routing/router.py
@@ -77,8 +77,6 @@ class BaseRouter(ABC):
                 )
             raise self.exception(str(e), path=path)
 
-        # handler_idx = param_basket.pop("__handler_idx__")
-        # raw_path = param_basket.pop("__raw_path__")
         params = param_basket.pop("__params__")
 
         if route.strict and orig and orig[-1] != route.path[-1]:

--- a/sanic_routing/router.py
+++ b/sanic_routing/router.py
@@ -111,7 +111,13 @@ class BaseRouter(ABC):
         strict: bool = False,
         unquote: bool = False,  # noqa
         overwrite: bool = False,
+        append: bool = False,
     ) -> Route:
+        if overwrite and append:
+            raise FinalizationError(
+                "Cannot add a route with both overwrite and append equal "
+                "to True"
+            )
         if not methods:
             methods = [self.DEFAULT_METHOD]
 
@@ -175,12 +181,12 @@ class BaseRouter(ABC):
         # and then as dynamic
         if not static and route.parts in self.static_routes:
             existing_group = self.static_routes.pop(route.parts)
-            group.merge(existing_group, overwrite)
+            group.merge(existing_group, overwrite, append)
 
         else:
             if route.parts in routes:
                 existing_group = routes[route.parts]
-                group.merge(existing_group, overwrite)
+                group.merge(existing_group, overwrite, append)
 
             routes[route.parts] = group
 

--- a/sanic_routing/tree.py
+++ b/sanic_routing/tree.py
@@ -1,9 +1,9 @@
 import typing as t
 from logging import getLogger
 
+from .group import RouteGroup
 from .line import Line
 from .patterns import REGEX_PARAM_NAME, REGEX_TYPES
-from .route import Route
 
 logger = getLogger("sanic.root")
 
@@ -19,16 +19,17 @@ class Node:
         self.children: t.Dict[str, "Node"] = {}
         self.level = 0
         self.offset = 0
-        self.route: t.Optional[Route] = None
+        self.group: t.Optional[RouteGroup] = None
         self.dynamic = False
         self.first = False
         self.last = False
         self.children_basketed = False
+        self.children_param_injected = False
 
-    def __repr__(self) -> str:
+    def __str__(self) -> str:
         internals = ", ".join(
             f"{prop}={getattr(self, prop)}"
-            for prop in ["part", "level", "route", "dynamic"]
+            for prop in ["part", "level", "group", "dynamic"]
             if getattr(self, prop) or prop in ["level"]
         )
         return f"<Node: {internals}>"
@@ -74,6 +75,7 @@ class Node:
     def to_src(self) -> t.Tuple[t.List[Line], t.List[Line]]:
         indent = (self.level + 1) * 2 - 3 + self.offset
         delayed: t.List[Line] = []
+        final: t.List[Line] = []
         src: t.List[Line] = []
 
         level = self.level - 1
@@ -81,31 +83,32 @@ class Node:
         len_check = ""
         return_bump = 1
 
-        if self.first or self.root:
-            src = []
-            operation = ">"
-            use_level = level
-            conditional = "if"
-            if (
-                self.last
-                and self.route
-                and not self.children
-                and not self.route.requirements
-                and not self.route.router.regex_routes
-            ):
-                use_level = self.level
-                operation = "=="
-                equality_check = True
-                conditional = "elif"
-                src.extend(
-                    [
-                        Line(f"if num > {use_level}:", indent),
-                        Line("raise NotFound", indent + 1),
-                    ]
+        if self.first:
+            if level == 0:
+                src.append(Line("if parts[0]:", indent))
+            else:
+                operation = ">"
+                use_level = level
+                conditional = "if"
+                if (
+                    self.last
+                    and self.group
+                    and not self.children
+                    and not self.group.requirements
+                ):
+                    use_level = self.level
+                    operation = "=="
+                    equality_check = True
+                    conditional = "elif"
+                    src.extend(
+                        [
+                            Line(f"if num > {use_level}:", indent),
+                            Line("raise NotFound", indent + 1),
+                        ]
+                    )
+                src.append(
+                    Line(f"{conditional} num {operation} {use_level}:", indent)
                 )
-            src.append(
-                Line(f"{conditional} num {operation} {use_level}:", indent)
-            )
 
         if self.dynamic:
             if not self.parent.children_basketed:
@@ -133,62 +136,106 @@ class Node:
             if self.children:
                 return_bump += 1
 
-        if self.route and not self.route.regex:
+        if self.group:
             location = delayed if self.children else src
-            if self.route.requirements:
+            route_idx: t.Union[int, str] = 0
+            if self.group.requirements:
+                route_idx = "route_idx"
                 self._inject_requirements(
                     location, indent + return_bump + bool(not self.children)
                 )
-            if self.route.params:
+            if self.group.params and not self.group.regex:
                 if not self.last:
                     return_bump += 1
                 self._inject_params(
-                    location, indent + return_bump + bool(not self.children)
+                    location,
+                    indent + return_bump + bool(not self.children),
+                    not self.parent.children_param_injected,
                 )
-            param_offset = bool(self.route.params)
+                if not self.parent.children_param_injected:
+                    self.parent.children_param_injected = True
+            param_offset = bool(self.group.params)
             return_indent = (
                 indent + return_bump + bool(not self.children) + param_offset
             )
+            if route_idx == 0 and len(self.group.routes) > 1:
+                route_idx = "route_idx"
+                for i, route in enumerate(self.group.routes):
+                    if_stmt = "if" if i == 0 else "elif"
+                    location.extend(
+                        [
+                            Line(
+                                f"{if_stmt} method in {route.methods}:",
+                                return_indent,
+                            ),
+                            Line(f"route_idx = {i}", return_indent + 1),
+                        ]
+                    )
+                location.extend(
+                    [
+                        Line("else:", return_indent),
+                        Line("raise NoMethod", return_indent + 1),
+                    ]
+                )
+            if self.group.regex:
+                return_indent += 1
+                location.extend(
+                    [
+                        Line(
+                            (
+                                "match = router.matchers"
+                                f"[{self.group.pattern_idx}].match(path)"
+                            ),
+                            return_indent - 1,
+                        ),
+                        Line("if match:", return_indent - 1),
+                        Line(
+                            "basket['__params__'] = match.groupdict()",
+                            return_indent,
+                        ),
+                    ]
+                )
+            routes = "regex_routes" if self.group.regex else "dynamic_routes"
             location.extend(
                 [
                     Line(
-                        (f"basket['__raw_path__'] = '{self.route.path}'"),
-                        return_indent,
-                    ),
-                    Line(
                         (
-                            f"return router.dynamic_routes[{self.route.parts}]"
-                            ", basket"
+                            f"return router.{routes}[{self.group.parts}]"
+                            f"[{route_idx}], basket"
                         ),
                         return_indent,
                     ),
-                    # Line("...", return_indent - 1, render=True),
                 ]
             )
-
-            if self.route.requirements and self.last and len_check:
-                location.append(Line("raise NotFound", return_indent - 1))
-
-            if self.route.params:
-                location.append(Line("...", return_indent - 1, render=False))
-                if self.last:
-                    location.append(
-                        Line("...", return_indent - 2, render=False),
-                    )
-        return src, delayed
+        return src, delayed + final
 
     def add_child(self, child: "Node") -> None:
         self._children[child.part] = child
 
     def _inject_requirements(self, location, indent):
-        for k, (idx, reqs) in enumerate(self.route.requirements.items()):
+        for k, route in enumerate(self.group):
+            if k == 0:
+                location.extend(
+                    [
+                        Line(f"if num > {self.level}:", indent),
+                        Line("raise NotFound", indent + 1),
+                    ]
+                )
+
             conditional = "if" if k == 0 else "elif"
             location.extend(
                 [
-                    Line((f"{conditional} extra == {reqs}:"), indent),
-                    Line((f"basket['__handler_idx__'] = {idx}"), indent + 1),
+                    Line(
+                        (
+                            f"{conditional} extra == {route.requirements} "
+                            f"and method in {route.methods}:"
+                        ),
+                        indent,
+                    ),
+                    Line((f"route_idx = {k}"), indent + 1),
                 ]
             )
+
         location.extend(
             [
                 Line(("else:"), indent),
@@ -196,20 +243,22 @@ class Node:
             ]
         )
 
-    def _inject_params(self, location, indent):
+    def _inject_params(self, location, indent, first_params):
         if self.last:
             lines = [
                 Line(f"if num > {self.level}:", indent),
                 Line("raise NotFound", indent + 1),
             ]
         else:
-            lines = [
-                Line(f"if num == {self.level}:", indent - 1),
-            ]
+            lines = []
+            if first_params:
+                lines.append(
+                    Line(f"if num == {self.level}:", indent - 1),
+                )
         lines.append(Line("try:", indent))
-        for idx, param in self.route.params.items():
-            unquote_start = "unquote(" if self.route.unquote else ""
-            unquote_end = ")" if self.route.unquote else ""
+        for idx, param in self.group.params.items():
+            unquote_start = "unquote(" if self.group.unquote else ""
+            unquote_end = ")" if self.group.unquote else ""
             lines.append(
                 Line(
                     f"basket['__params__']['{param.name}'] = "
@@ -229,7 +278,7 @@ class Node:
         )
 
     @staticmethod
-    def _sorting(item) -> t.Tuple[bool, int, str, int]:
+    def _sorting(item) -> t.Tuple[bool, int, str, bool, int]:
         key, child = item
         type_ = 0
         if child.dynamic:
@@ -240,7 +289,13 @@ class Node:
                     type_ = list(REGEX_TYPES.keys()).index(param_type)
                 except ValueError:
                     type_ = len(list(REGEX_TYPES.keys()))
-        return child.dynamic, len(child._children), key, type_ * -1
+        return (
+            child.dynamic,
+            len(child._children),
+            key,
+            bool(child.group and child.group.regex),
+            type_ * -1,
+        )
 
 
 class Tree:
@@ -248,10 +303,10 @@ class Tree:
         self.root = Node(root=True)
         self.root.level = 0
 
-    def generate(self, routes: t.Dict[t.Tuple[str, ...], Route]) -> None:
-        for route in routes.values():
+    def generate(self, groups: t.Iterable[RouteGroup]) -> None:
+        for group in groups:
             current = self.root
-            for level, part in enumerate(route.parts):
+            for level, part in enumerate(group.parts):
                 if part not in current._children:
                     current.add_child(Node(part=part, parent=current))
                 current = current._children[part]
@@ -261,7 +316,7 @@ class Tree:
                 if current.dynamic and not REGEX_PARAM_NAME.match(part):
                     raise ValueError(f"Invalid declaration: {part}")
 
-            current.route = route
+            current.group = group
 
     def display(self) -> None:
         """

--- a/sanic_routing/tree.py
+++ b/sanic_routing/tree.py
@@ -195,12 +195,15 @@ class Node:
                     not self.parent.children_param_injected,
                 )
             routes = "regex_routes" if self.group.regex else "dynamic_routes"
+            route_return = (
+                "" if self.group.router.stacking else f"[{route_idx}]"
+            )
             location.extend(
                 [
                     Line(
                         (
                             f"return router.{routes}[{self.group.parts}]"
-                            f"[{route_idx}], basket"
+                            f"{route_return}, basket"
                         ),
                         return_indent,
                     ),

--- a/sanic_routing/tree.py
+++ b/sanic_routing/tree.py
@@ -54,13 +54,13 @@ class Node:
         for child in self.children.values():
             child.display()
 
-    def render(self) -> t.List[Line]:
+    def render(self) -> t.Tuple[t.List[Line], t.List[Line]]:
+        output: t.List[Line] = []
+        delayed: t.List[Line] = []
+        final: t.List[Line] = []
+
         if not self.root:
             output, delayed, final = self.to_src()
-        else:
-            output = []
-            delayed = []
-            final = []
         for child in self.children.values():
             o, f = child.render()
             output += o
@@ -74,7 +74,7 @@ class Node:
             for child in self.children.values():
                 child.apply_offset(amt, apply_children=True)
 
-    def to_src(self) -> t.Tuple[t.List[Line], t.List[Line]]:
+    def to_src(self) -> t.Tuple[t.List[Line], t.List[Line], t.List[Line]]:
         indent = (self.level + 1) * 2 - 3 + self.offset
         delayed: t.List[Line] = []
         final: t.List[Line] = []

--- a/tests/test_router_source.py
+++ b/tests/test_router_source.py
@@ -10,8 +10,8 @@ class Router(BaseRouter):
 @pytest.mark.parametrize(
     "cascade,lines,not_founds",
     (
-        (True, 32, 6),
-        (False, 30, 4),
+        (True, 32, 8),
+        (False, 28, 4),
     ),
 )
 def test_route_correct_coercion(cascade, lines, not_founds):
@@ -23,5 +23,6 @@ def test_route_correct_coercion(cascade, lines, not_founds):
     router.add("/<one>/two/three", handler)
 
     router.finalize()
+
     assert router.find_route_src.count("\n") == lines
     assert router.find_route_src.count("raise NotFound") == not_founds

--- a/tests/test_router_source.py
+++ b/tests/test_router_source.py
@@ -1,4 +1,5 @@
 import pytest
+
 from sanic_routing import BaseRouter
 
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -142,7 +142,11 @@ def test_casting(handler, label, value, cast_type):
 def test_conditional_check_proper_compile(handler):
     router = Router()
     router.add("/<foo>/", handler, strict=True)
-    router.add("/<foo>/", handler, strict=True, requirements={"foo": "bar"})
+
+    with pytest.raises(RouteExists):
+        router.add(
+            "/<foo>/", handler, strict=True, requirements={"foo": "bar"}
+        )
     router.finalize()
 
     assert router.finalized

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import date
 
 import pytest
+
 from sanic_routing import BaseRouter
 from sanic_routing.exceptions import NoMethod, NotFound, RouteExists
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -43,14 +43,18 @@ def test_add_duplicate_route_fails():
     router = Router()
 
     router.add("/foo/bar", lambda *args, **kwargs: ...)
+    assert len(router.routes) == 1
     with pytest.raises(RouteExists):
         router.add("/foo/bar", lambda *args, **kwargs: ...)
     router.add("/foo/bar", lambda *args, **kwargs: ..., overwrite=True)
+    assert len(router.routes) == 1
 
     router.add("/foo/<bar>", lambda *args, **kwargs: ...)
+    assert len(router.routes) == 2
     with pytest.raises(RouteExists):
         router.add("/foo/<bar>", lambda *args, **kwargs: ...)
     router.add("/foo/<bar>", lambda *args, **kwargs: ..., overwrite=True)
+    assert len(router.routes) == 2
 
 
 def test_add_duplicate_route_alt_method():
@@ -63,14 +67,12 @@ def test_add_duplicate_route_alt_method():
     assert len(router.static_routes) == 1
     assert len(router.dynamic_routes) == 2
 
-    static_handlers = list(
-        list(router.static_routes.values())[0].handlers.values()
-    )
-    assert len(static_handlers[0]) == 2
+    static_handlers = list(router.static_routes.values())[0]
+    assert len(static_handlers.routes) == 2
 
-    for route in router.dynamic_routes.values():
-        assert len(list(route.handlers.values())) == 1
-        assert len(list(route.handlers.values())) == 1
+    for group in router.dynamic_routes.values():
+        assert len(group.routes) == 1
+        assert len(group.routes) == 1
 
 
 def test_route_does_not_exist():
@@ -160,7 +162,7 @@ def test_use_param_name(handler, param_name):
     path_part_with_param = f"<{param_name}>"
     router.add(f"/path/{path_part_with_param}", handler)
     route = list(router.routes)[0]
-    assert ("path", path_part_with_param) == route
+    assert ("path", path_part_with_param) == route.parts
 
 
 @pytest.mark.parametrize(
@@ -177,7 +179,7 @@ def test_use_param_name_with_casing(handler, param_name):
     path_part_with_param = f"<{param_name}:str>"
     router.add(f"/path/{path_part_with_param}", handler)
     route = list(router.routes)[0]
-    assert ("path", path_part_with_param) == route
+    assert ("path", path_part_with_param) == route.parts
 
 
 def test_use_route_contains_children(handler):
@@ -223,8 +225,8 @@ def test_use_route_with_different_depth(handler):
     router.get("/foo/123/settings", "BASE")
     router.get("/foo/123/bars/321/settings", "BASE")
     router.get("/foo/123/bars_ids", "BASE")
-    router.get("/foo/123/bars_ids/321/settings", "BASE")
-    router.get("/foo/123/bars_ids/321/settings/111/groups", "BASE")
+    # router.get("/foo/123/bars_ids/321/settings", "BASE")
+    # router.get("/foo/123/bars_ids/321/settings/111/groups", "BASE")
 
 
 def test_use_route_type_coercion(handler):

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -229,8 +229,8 @@ def test_use_route_with_different_depth(handler):
     router.get("/foo/123/settings", "BASE")
     router.get("/foo/123/bars/321/settings", "BASE")
     router.get("/foo/123/bars_ids", "BASE")
-    # router.get("/foo/123/bars_ids/321/settings", "BASE")
-    # router.get("/foo/123/bars_ids/321/settings/111/groups", "BASE")
+    router.get("/foo/123/bars_ids/321/settings", "BASE")
+    router.get("/foo/123/bars_ids/321/settings/111/groups", "BASE")
 
 
 def test_use_route_type_coercion(handler):


### PR DESCRIPTION
Resolves #23 

Also:
- https://github.com/sanic-org/sanic/issues/2103
- https://github.com/sanic-org/sanic/issues/2090
- https://github.com/sanic-org/sanic/issues/2089

---

## Background

The main idea behind this is twofold:

1. regex routes are evaluated in the node tree along with other dynamic paths
2. **ALL** routes are now nested in a `RouteGroup`

The practical impact of this second item is that every route definition will have its own `Route` object. This should allow things like `strict`, `name`, and `requirements` to be set per `Route`, while things like `methods` can be grouped for proper routing.

---

## Example

Some definitions:

```python
# CONTROL
router.add("/foo", partial(handler, 1), methods=["get", "put"])

# REQUIREMENTS
router.add("/<foo>", partial(handler, 2), methods=["put"], requirements={"1": 3})
router.add("/<foo>", partial(handler, 3), methods=["put"], requirements={"1": 2})
router.add("/<foo>", partial(handler, 4), methods=["get"], requirements={"1": 2})

# OVERLOAD METHOD
router.add("/<foo>/bar", partial(handler, 5), methods=["put"])
router.add("/<foo>/bar", partial(handler, 6), methods=["patch"])


# OVERLOAD PARAM TYPE
router.add("/nested/<foo:[a-z]qqq>/", partial(handler, 7))
router.add("/nested/<foo:int>/", partial(handler, 8))
router.add("/nested/<foo:uuid>/", partial(handler, 9))
```

There are **only six (6) groups**. Routes are grouped together if they share the same `raw_path`. This means that routes on the same path, but different methods or different requirements are grouped together.

```
GROUPS (6)
	- <RouteGroup: path=foo len=1>
		group.methods=frozenset({'put', 'get'})
		group.params={}
		group.requirements=[]
	- <RouteGroup: path=<foo> len=3>
		group.methods=frozenset({'put', 'get'})
		group.params={0: ParamInfo(name='foo', raw_path='<foo>', label='string', cast=<class 'str'>, pattern=None, regex=False)}
		group.requirements=[{'1': 2}, {'1': 2}, {'1': 3}]
	- <RouteGroup: path=<foo>/bar len=2>
		group.methods=frozenset({'patch', 'put'})
		group.params={0: ParamInfo(name='foo', raw_path='<foo>/bar', label='string', cast=<class 'str'>, pattern=None, regex=False)}
		group.requirements=[]
	- <RouteGroup: path=nested/<foo:int> len=1>
		group.methods=frozenset({'BASE'})
		group.params={1: ParamInfo(name='foo', raw_path='nested/<foo:int>', label='int', cast=<class 'int'>, pattern=re.compile('^-?\\d+'), regex=False)}
		group.requirements=[]
	- <RouteGroup: path=nested/<foo:uuid> len=1>
		group.methods=frozenset({'BASE'})
		group.params={1: ParamInfo(name='foo', raw_path='nested/<foo:uuid>', label='uuid', cast=<class 'uuid.UUID'>, pattern=re.compile('^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}'), regex=False)}
		group.requirements=[]
	- <RouteGroup: path=nested/<foo:[a-z]qqq> len=1>
		group.methods=frozenset({'BASE'})
		group.params={1: ParamInfo(name='foo', raw_path='nested/<foo:[a-z]qqq>', label='[a-z]qqq', cast=<class 'str'>, pattern=re.compile('^[a-z]qqq$'), regex=True)}
		group.requirements=[]
```

But, we called `add()` nine times. Therefore, there are **nine (9)** defined routes. Note that when multiple methods are defined in a single definition, it still counts as a single route.

```
ROUTES (9)
	- <Route: path=foo>
		route.handler=functools.partial(<function handler at 0x7ff443bb60d0>, 1)
		route.methods=frozenset({'put', 'get'})
		route.params={}
		route.requirements={}
	- <Route: path=<foo>>
		route.handler=functools.partial(<function handler at 0x7ff443bb60d0>, 4)
		route.methods=frozenset({'get'})
		route.params={0: ParamInfo(name='foo', raw_path='<foo>', label='string', cast=<class 'str'>, pattern=None, regex=False)}
		route.requirements={'1': 2}
	- <Route: path=<foo>>
		route.handler=functools.partial(<function handler at 0x7ff443bb60d0>, 3)
		route.methods=frozenset({'put'})
		route.params={0: ParamInfo(name='foo', raw_path='<foo>', label='string', cast=<class 'str'>, pattern=None, regex=False)}
		route.requirements={'1': 2}
	- <Route: path=<foo>>
		route.handler=functools.partial(<function handler at 0x7ff443bb60d0>, 2)
		route.methods=frozenset({'put'})
		route.params={0: ParamInfo(name='foo', raw_path='<foo>', label='string', cast=<class 'str'>, pattern=None, regex=False)}
		route.requirements={'1': 3}
	- <Route: path=<foo>/bar>
		route.handler=functools.partial(<function handler at 0x7ff443bb60d0>, 6)
		route.methods=frozenset({'patch'})
		route.params={0: ParamInfo(name='foo', raw_path='<foo>/bar', label='string', cast=<class 'str'>, pattern=None, regex=False)}
		route.requirements={}
	- <Route: path=<foo>/bar>
		route.handler=functools.partial(<function handler at 0x7ff443bb60d0>, 5)
		route.methods=frozenset({'put'})
		route.params={0: ParamInfo(name='foo', raw_path='<foo>/bar', label='string', cast=<class 'str'>, pattern=None, regex=False)}
		route.requirements={}
	- <Route: path=nested/<foo:int>>
		route.handler=functools.partial(<function handler at 0x7ff443bb60d0>, 2)
		route.methods=frozenset({'BASE'})
		route.params={1: ParamInfo(name='foo', raw_path='nested/<foo:int>', label='int', cast=<class 'int'>, pattern=re.compile('^-?\\d+'), regex=False)}
		route.requirements={}
	- <Route: path=nested/<foo:uuid>>
		route.handler=functools.partial(<function handler at 0x7ff443bb60d0>, 3)
		route.methods=frozenset({'BASE'})
		route.params={1: ParamInfo(name='foo', raw_path='nested/<foo:uuid>', label='uuid', cast=<class 'uuid.UUID'>, pattern=re.compile('^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}'), regex=False)}
		route.requirements={}
	- <Route: path=nested/<foo:[a-z]qqq>>
		route.handler=functools.partial(<function handler at 0x7ff443bb60d0>, 1)
		route.methods=frozenset({'BASE'})
		route.params={1: ParamInfo(name='foo', raw_path='nested/<foo:[a-z]qqq>', label='[a-z]qqq', cast=<class 'str'>, pattern=re.compile('^[a-z]qqq$'), regex=True)}
		route.requirements={}
```

When we break the routes--*dynamic only*--into a tree, it looks like this:

```
<Node: level=0>
    <Node: part=nested, level=1>
        <Node: part=<foo:uuid>, level=2, group=<RouteGroup: path=nested/<foo:uuid> len=1>, dynamic=True>
        <Node: part=<foo:int>, level=2, group=<RouteGroup: path=nested/<foo:int> len=1>, dynamic=True>
        <Node: part=<foo:[a-z]qqq>, level=2, group=<RouteGroup: path=nested/<foo:[a-z]qqq> len=1>, dynamic=True>
    <Node: part=<foo>, level=1, group=<RouteGroup: path=<foo> len=3>, dynamic=True>
        <Node: part=bar, level=2, group=<RouteGroup: path=<foo>/bar len=2>>
```

This is the basis for the source code generation:

```python
def find_route(path, method, router, basket, extra):
    parts = tuple(path[1:].split(router.delimiter))
    try:
        route = router.static_routes[parts][0]
        basket['__raw_path__'] = path
        return route, basket
    except KeyError:
        pass
    num = len(parts)
    if parts[0]:
        if parts[0] == "nested":
            if num > 1:
                basket[1] = parts[1]
                if num == 2:
                    try:
                        basket['__params__']['foo'] = UUID(basket[1])
                    except (ValueError, KeyError):
                        pass
                    else:
                        return router.dynamic_routes[('nested', '<foo:uuid>')][0], basket
                    try:
                        basket['__params__']['foo'] = int(basket[1])
                    except (ValueError, KeyError):
                        pass
                    else:
                        return router.dynamic_routes[('nested', '<foo:int>')][0], basket
                    match = router.matchers[0].match(path)
                    if match:
                        basket['__params__'] = match.groupdict()
                        return router.regex_routes[('nested', '<foo:[a-z]qqq>')][0], basket
        basket[0] = parts[0]
        if num > 2:
            raise NotFound
        elif num == 2:
            if parts[1] == "bar":
                if num > 2:
                    raise NotFound
                try:
                    basket['__params__']['foo'] = str(basket[0])
                except (ValueError, KeyError):
                    pass
                else:
                    if method in frozenset({'patch'}):
                        route_idx = 0
                    elif method in frozenset({'put'}):
                        route_idx = 1
                    else:
                        raise NoMethod
                    return router.dynamic_routes[('<foo>', 'bar')][route_idx], basket
        if num > 1:
            raise NotFound
        if extra == {'1': 2} and method in frozenset({'get'}):
            route_idx = 0
        elif extra == {'1': 2} and method in frozenset({'put'}):
            route_idx = 1
        elif extra == {'1': 3} and method in frozenset({'put'}):
            route_idx = 2
        else:
            raise NotFound
        if num > 1:
            raise NotFound
        try:
            basket['__params__']['foo'] = str(basket[0])
        except (ValueError, KeyError):
            pass
        else:
            return router.dynamic_routes[('<foo>',)][route_idx], basket
    raise NotFound
matchers = [
    re.compile(r'^/nested/(?P<foo>[a-z]qqq)$'),
]
```