### PR TITLE
Fix cases where a regex part after a dynamic part might result in a 404

### DIFF
--- a/sanic_routing/route.py
+++ b/sanic_routing/route.py
@@ -138,7 +138,6 @@ class Route:
         cast: t.Type,
         pattern=None,
     ):
-        print(f"Adding {idx=} {name=} {label=} {pattern=}")
         if pattern and isinstance(pattern, str):
             if not pattern.startswith("^"):
                 pattern = f"^{pattern}"

--- a/sanic_routing/route.py
+++ b/sanic_routing/route.py
@@ -121,7 +121,12 @@ class Route:
                         )
                     else:
                         self.add_parameter(
-                            idx, part[1:-1], key_path, "string", str, None
+                            idx,
+                            part[1:-1],
+                            key_path,
+                            "string",
+                            str,
+                            REGEX_TYPES["string"],
                         )
 
     def add_parameter(
@@ -133,6 +138,7 @@ class Route:
         cast: t.Type,
         pattern=None,
     ):
+        print(f"Adding {idx=} {name=} {label=} {pattern=}")
         if pattern and isinstance(pattern, str):
             if not pattern.startswith("^"):
                 pattern = f"^{pattern}"
@@ -162,7 +168,7 @@ class Route:
         components = []
 
         for part in self.parts:
-            if ":" in part:
+            if part.startswith("<"):
                 name, *_, pattern = self.parse_parameter_string(part)
                 if not isinstance(pattern, str):
                     pattern = pattern.pattern.strip("^$")

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import date
 
 import pytest
+
 from sanic_routing import BaseRouter
 from sanic_routing.exceptions import NoMethod, NotFound, RouteExists
 


### PR DESCRIPTION
Closes #26 

Use case:

```python
from sanic.router import Router

def handler(*args):
    print(args)

router = Router()
router.add("/<foo>", ["GET"], handler)
router.add(r"/<foo>/<invoice:(?P<invoice>[0-9]+)\.pdf>", ["GET"], handler)

router.finalize()
print(router.find_route_src)

router.get("/something/123.pdf", "GET", None)
```