### PR TITLE
Add API for custom parameter types

### DIFF
--- a/sanic_routing/router.py
+++ b/sanic_routing/router.py
@@ -4,7 +4,13 @@ from types import SimpleNamespace
 
 from sanic_routing.group import RouteGroup
 
-from .exceptions import BadMethod, FinalizationError, NoMethod, NotFound
+from .exceptions import (
+    BadMethod,
+    FinalizationError,
+    InvalidUsage,
+    NoMethod,
+    NotFound,
+)
 from .line import Line
 from .patterns import REGEX_TYPES
 from .route import Route
@@ -45,11 +51,13 @@ class BaseRouter(ABC):
         self.method_handler_exception = method_handler_exception
         self.route_class = route_class
         self.group_class = group_class
-        self.tree = Tree()
+        self.tree = Tree(router=self)
         self.finalized = False
         self.stacking = stacking
         self.ctx = SimpleNamespace()
         self.cascade_not_found = cascade_not_found
+
+        self.regex_types = {**REGEX_TYPES}
 
     @abstractmethod
     def get(self, **kwargs):
@@ -197,6 +205,26 @@ class BaseRouter(ABC):
 
         return route
 
+    def register_pattern(self, label, cast, pattern):
+        if not isinstance(label, str):
+            raise InvalidUsage(
+                "When registering a pattern, label must be a "
+                f"string, not {label=}"
+            )
+        if not callable(cast):
+            raise InvalidUsage(
+                "When registering a pattern, cast must be a "
+                f"callable, not {cast=}"
+            )
+        if not isinstance(pattern, str):
+            raise InvalidUsage(
+                "When registering a pattern, pattern must be a "
+                f"string, not {pattern=}"
+            )
+
+        globals()[cast.__name__] = cast
+        self.regex_types[label] = (cast, pattern)
+
     def finalize(self, do_compile: bool = True):
         if self.finalized:
             raise FinalizationError("Cannot finalize router more than once.")
@@ -218,7 +246,7 @@ class BaseRouter(ABC):
 
     def reset(self):
         self.finalized = False
-        self.tree = Tree()
+        self.tree = Tree(router=self)
         self._find_route = None
 
         for group in (
@@ -397,7 +425,7 @@ class BaseRouter(ABC):
             return (
                 part.endswith(":path>")
                 or self.delimiter in part
-                or pattern_type not in REGEX_TYPES
+                or pattern_type not in self.regex_types
             )
 
         return any(requires(part) for part in parts)

--- a/sanic_routing/router.py
+++ b/sanic_routing/router.py
@@ -209,17 +209,17 @@ class BaseRouter(ABC):
         if not isinstance(label, str):
             raise InvalidUsage(
                 "When registering a pattern, label must be a "
-                f"string, not {label=}"
+                f"string, not label={label}"
             )
         if not callable(cast):
             raise InvalidUsage(
                 "When registering a pattern, cast must be a "
-                f"callable, not {cast=}"
+                f"callable, not cast={cast}"
             )
         if not isinstance(pattern, str):
             raise InvalidUsage(
                 "When registering a pattern, pattern must be a "
-                f"string, not {pattern=}"
+                f"string, not pattern={pattern}"
             )
 
         globals()[cast.__name__] = cast

--- a/sanic_routing/tree.py
+++ b/sanic_routing/tree.py
@@ -3,14 +3,14 @@ from logging import getLogger
 
 from .group import RouteGroup
 from .line import Line
-from .patterns import REGEX_PARAM_NAME, REGEX_TYPES
+from .patterns import REGEX_PARAM_NAME
 
 logger = getLogger("sanic.root")
 
 
 class Node:
     def __init__(
-        self, part: str = "", root: bool = False, parent=None
+        self, part: str = "", root: bool = False, parent=None, router=None
     ) -> None:
         self.root = root
         self.part = part
@@ -26,6 +26,7 @@ class Node:
         self.children_basketed = False
         self.children_param_injected = False
         self.has_deferred = False
+        self.router = router
 
     def __str__(self) -> str:
         internals = ", ".join(
@@ -324,8 +325,16 @@ class Node:
                     return True
         return False
 
-    @staticmethod
-    def _sorting(item) -> t.Tuple[bool, int, str, bool, int]:
+    def _has_nested_regex(self, node, recursive=True):
+        if node.group and node.group.regex:
+            return True
+        if recursive and node.children:
+            for child in node.children.values():
+                if self._has_nested_regex(child):
+                    return True
+        return False
+
+    def _sorting(self, item) -> t.Tuple[bool, int, str, bool, int]:
         key, child = item
         type_ = 0
         if child.dynamic:
@@ -333,9 +342,11 @@ class Node:
             if ":" in key:
                 key, param_type = key.split(":", 1)
                 try:
-                    type_ = list(REGEX_TYPES.keys()).index(param_type)
+                    type_ = list(self.router.regex_types.keys()).index(
+                        param_type
+                    )
                 except ValueError:
-                    type_ = len(list(REGEX_TYPES.keys()))
+                    type_ = len(list(self.router.regex_types.keys()))
         return (
             child.dynamic,
             len(child._children),
@@ -346,16 +357,19 @@ class Node:
 
 
 class Tree:
-    def __init__(self) -> None:
-        self.root = Node(root=True)
+    def __init__(self, router) -> None:
+        self.root = Node(root=True, router=router)
         self.root.level = 0
+        self.router = router
 
     def generate(self, groups: t.Iterable[RouteGroup]) -> None:
         for group in groups:
             current = self.root
             for level, part in enumerate(group.parts):
                 if part not in current._children:
-                    current.add_child(Node(part=part, parent=current))
+                    current.add_child(
+                        Node(part=part, parent=current, router=self.router)
+                    )
                 current = current._children[part]
                 current.level = level + 1
 

--- a/tests/test_custom_param_types.py
+++ b/tests/test_custom_param_types.py
@@ -1,0 +1,48 @@
+import ipaddress
+
+import pytest
+from sanic_routing import BaseRouter
+from sanic_routing.exceptions import InvalidUsage
+
+
+@pytest.fixture
+def handler():
+    def handler(**kwargs):
+        return list(kwargs.values())[0]
+
+    return handler
+
+
+class Router(BaseRouter):
+    def get(self, path, method, extra=None):
+        return self.resolve(path=path, method=method, extra=extra)
+
+
+def test_does_cast(handler):
+    router = Router()
+    router.register_pattern(
+        "ipv4",
+        ipaddress.ip_address,
+        r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$",
+    )
+
+    router.add("/<ip:ipv4>", handler)
+    router.finalize()
+
+    _, handler, params = router.get("/1.2.3.4", "BASE")
+    retval = handler(**params)
+
+    assert isinstance(retval, ipaddress.IPv4Address)
+
+
+def test_bad_registries():
+    router = Router()
+
+    with pytest.raises(InvalidUsage):
+        router.register_pattern(None, None, None)
+
+    with pytest.raises(InvalidUsage):
+        router.register_pattern("ipv4", None, None)
+
+    with pytest.raises(InvalidUsage):
+        router.register_pattern("ipv4", ipaddress.ip_address, None)

--- a/tests/test_custom_param_types.py
+++ b/tests/test_custom_param_types.py
@@ -1,6 +1,7 @@
 import ipaddress
 
 import pytest
+
 from sanic_routing import BaseRouter
 from sanic_routing.exceptions import InvalidUsage
 

--- a/tests/test_custom_param_types.py
+++ b/tests/test_custom_param_types.py
@@ -1,9 +1,8 @@
 import ipaddress
 
 import pytest
-
 from sanic_routing import BaseRouter
-from sanic_routing.exceptions import InvalidUsage
+from sanic_routing.exceptions import InvalidUsage, NotFound
 
 
 @pytest.fixture
@@ -34,6 +33,21 @@ def test_does_cast(handler):
     retval = handler(**params)
 
     assert isinstance(retval, ipaddress.IPv4Address)
+
+
+def test_does_not_cast(handler):
+    router = Router()
+    router.register_pattern(
+        "ipv4",
+        ipaddress.ip_address,
+        r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$",
+    )
+
+    router.add("/<ip:ipv4>", handler)
+    router.finalize()
+
+    with pytest.raises(NotFound):
+        router.get("/notfound", "BASE")
 
 
 def test_bad_registries():

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import date
 
 import pytest
+
 from sanic_routing import BaseRouter
 from sanic_routing.exceptions import NoMethod, NotFound, RouteExists
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = py36, py37, py38, py39, lint
+envlist = py37, py38, py39, lint
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38, lint
     3.9: py39


### PR DESCRIPTION
Use case:

```python
router.register_pattern(
    "ipv4",
    ipaddress.ip_address,
    r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$",
)
router.add("/<ip:ipv4>", ["GET"], handler)
```

Source should look something like this:

```python
def find_route(path, method, router, basket, extra):
    parts = tuple(path[1:].split(router.delimiter))
    num = len(parts)
    if True:
        basket[0] = parts[0]
        if num > 1:
            raise NotFound
        try:
            basket['__params__']['ip'] = ip_address(basket[0])
        except (ValueError, KeyError):
            pass
        else:
            return router.dynamic_routes[('<ip:ipv4>',)][0], basket
    raise NotFound
```

And, when matching: `/1.2.3.4`:

```
{'ip': IPv4Address('1.2.3.4')}
```