### PR TITLE
Catch duplicate dynamics

### DIFF
--- a/sanic_routing/route.py
+++ b/sanic_routing/route.py
@@ -90,11 +90,11 @@ class Route:
             return False
         return bool(
             (
-                self.parts,
+                self.segments,
                 self.requirements,
             )
             == (
-                other.parts,
+                other.segments,
                 other.requirements,
             )
             and (self.methods & other.methods)
@@ -195,6 +195,13 @@ class Route:
             components
         )
 
+    def _part_to_segment(self, part):
+        if not part.startswith("<"):
+            return part
+
+        parsed = self.parse_parameter_string(part)
+        return f"<{parsed[1]}>"
+
     def finalize(self):
         self._finalize_params()
         if self.regex:
@@ -211,6 +218,10 @@ class Route:
     @property
     def raw_path(self):
         return self._raw_path
+
+    @property
+    def segments(self):
+        return tuple([self._part_to_segment(part) for part in self.parts])
 
     @staticmethod
     def _sorting(item) -> int:

--- a/sanic_routing/router.py
+++ b/sanic_routing/router.py
@@ -174,21 +174,21 @@ class BaseRouter(ABC):
 
         # Catch the scenario where a route is overloaded with and
         # and without requirements, first as dynamic then as static
-        if static and route.parts in self.dynamic_routes:
+        if static and route.segments in self.dynamic_routes:
             routes = self.dynamic_routes
 
         # Catch the reverse scenario where a route is overload first as static
         # and then as dynamic
-        if not static and route.parts in self.static_routes:
-            existing_group = self.static_routes.pop(route.parts)
+        if not static and route.segments in self.static_routes:
+            existing_group = self.static_routes.pop(route.segments)
             group.merge(existing_group, overwrite, append)
 
         else:
-            if route.parts in routes:
-                existing_group = routes[route.parts]
+            if route.segments in routes:
+                existing_group = routes[route.segments]
                 group.merge(existing_group, overwrite, append)
 
-            routes[route.parts] = group
+            routes[route.segments] = group
 
         if name:
             self.name_index[name] = route

--- a/sanic_routing/tree.py
+++ b/sanic_routing/tree.py
@@ -325,7 +325,9 @@ class Node:
         return False
 
     @staticmethod
-    def _sorting(item) -> t.Tuple[bool, int, str, bool, int]:
+    def _sorting(
+        item,
+    ) -> t.Tuple[bool, int, bool, int, str]:
         key, child = item
         type_ = 0
         if child.dynamic:
@@ -339,9 +341,9 @@ class Node:
         return (
             child.dynamic,
             len(child._children),
-            key,
             bool(child.group and child.group.regex),
             type_ * -1,
+            key,
         )
 
 


### PR DESCRIPTION
Closes #28 

This forces the route objects to ignore variable names in otherwise similar paths.

- [ ] Tests