### PR TITLE
Add casting to regex matching

### DIFF
--- a/sanic_routing/router.py
+++ b/sanic_routing/router.py
@@ -105,13 +105,19 @@ class BaseRouter(ABC):
                     allowed_methods=route.methods,
                 )
 
-        # Regex routes evaluate and can extract params directly. They are set
-        # on param_basket["__params__"]
+        # Convert matched values to parameters
         params = param_basket["__params__"]
-        if not params:
-            # If param_basket["__params__"] does not exist, we might have
-            # param_basket["__matches__"], which are indexed based matches
-            # on path segments. They should already be cast types.
+        if route.regex:
+            params.update(
+                {
+                    param.name: param.cast(
+                        param_basket["__params__"][param.name]
+                    )
+                    for param in route.params.values()
+                    if param.cast is not str
+                }
+            )
+        elif param_basket["__matches__"]:
             params = {
                 param.name: param_basket["__matches__"][idx]
                 for idx, param in route.params.items()

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -2,7 +2,6 @@ import uuid
 from datetime import date
 
 import pytest
-
 from sanic_routing import BaseRouter
 from sanic_routing.exceptions import NoMethod, NotFound, RouteExists
 
@@ -481,7 +480,7 @@ def test_identical_path_routes_with_different_methods_complex(uri):
 
     _, handler, params = router.get(f"/api/3/hello_world/{uri}", "GET")
     assert handler() == "handler2"
-    assert params == {"version": "3", "foo": uri}
+    assert params == {"version": 3, "foo": uri}
 
 
 @pytest.mark.parametrize("uri", ("a-random-path", "a/random/path"))
@@ -497,9 +496,15 @@ def test_identical_path_routes_with_different_methods_similar_urls(uri):
 
     # test root level path with different methods
     router = Router()
-    router.add("/constant/<foo:path>/story", handler1, methods=["GET", "OPTIONS"])
-    router.add("/constant/<foo:path>/tracker/events", handler2, methods=["PUT"])
-    router.add("/constant/<foo:path>/tracker/events", handler3, methods=["POST"])
+    router.add(
+        "/constant/<foo:path>/story", handler1, methods=["GET", "OPTIONS"]
+    )
+    router.add(
+        "/constant/<foo:path>/tracker/events", handler2, methods=["PUT"]
+    )
+    router.add(
+        "/constant/<foo:path>/tracker/events", handler3, methods=["POST"]
+    )
     router.finalize()
 
     route, handler, params = router.get(f"/constant/{uri}/story", "GET")


### PR DESCRIPTION
Closes #46 

While this implementation does fulfill the requirements, I am wondering if instead we should embed the casting for regex into the dynamic code so that we do not need to waste time checking for the non-regex routes.