### PR TITLE
router: Fix missing requirement checks for regex routes

### DIFF
--- a/sanic_routing/router.py
+++ b/sanic_routing/router.py
@@ -425,7 +425,10 @@ class BaseRouter(ABC):
             route_idx: t.Union[str, int] = 0
             holder: t.List[Line] = []
 
-            if len(group.routes) > 1:
+            if group.requirements:
+                route_idx = "route_idx"
+                Node._inject_requirements(holder, 2, group)
+            elif len(group.routes) > 1:
                 route_idx = "route_idx"
                 Node._inject_method_check(holder, 2, group)
 

--- a/sanic_routing/tree.py
+++ b/sanic_routing/tree.py
@@ -322,7 +322,8 @@ class Node:
             ]
         )
 
-    def _inject_requirements(self, location, indent, group):
+    @staticmethod
+    def _inject_requirements(location, indent, group):
         """
         Check any extra checks needed for a route. In path routing, for exampe,
         this is used for matching vhosts.


### PR DESCRIPTION
Since `Node._inject_requirements` also injects a method check, it doesn't need to be injected explicitly again.