### PR TITLE
Fixed: change typing on register_pattern

### DIFF
--- a/sanic_routing/router.py
+++ b/sanic_routing/router.py
@@ -238,10 +238,13 @@ class BaseRouter(ABC):
         return route
 
     def register_pattern(
-        self, label: str, cast: t.Callable[[str], t.Any], pattern: str
+        self,
+        label: str,
+        cast: t.Callable[[str], t.Any],
+        pattern: t.Union[t.Pattern, str]
     ):
         """
-        Add a custom parameter type to the router. The cast shoud raise a
+        Add a custom parameter type to the router. The cast should raise a
         ValueError if it is an incorrect type. The order of registration is
         important if it is possible that a single value could pass multiple
         pattern types. Therefore, patterns are tried in the REVERSE order of
@@ -256,7 +259,7 @@ class BaseRouter(ABC):
         :type cast: t.Callable[[str], t.Any]
         :param pattern: A regular expression that could also match the path
             segment
-        :type pattern: str
+        :type pattern: Union[t.Pattern, str]
         """
         if not isinstance(label, str):
             raise InvalidUsage(
@@ -268,10 +271,11 @@ class BaseRouter(ABC):
                 "When registering a pattern, cast must be a "
                 f"callable, not cast={cast}"
             )
-        if not isinstance(pattern, str):
+        if not isinstance(pattern, str) and not isinstance(pattern, t.Pattern):
             raise InvalidUsage(
                 "When registering a pattern, pattern must be a "
-                f"string, not pattern={pattern}"
+                f"string or a Pattern, not pattern={pattern}, "
+                f"type={type(pattern)}"
             )
 
         globals()[cast.__name__] = cast

--- a/sanic_routing/router.py
+++ b/sanic_routing/router.py
@@ -241,7 +241,7 @@ class BaseRouter(ABC):
         self,
         label: str,
         cast: t.Callable[[str], t.Any],
-        pattern: t.Union[t.Pattern, str]
+        pattern: t.Union[t.Pattern, str],
     ):
         """
         Add a custom parameter type to the router. The cast should raise a
@@ -277,6 +277,9 @@ class BaseRouter(ABC):
                 f"string or a Pattern, not pattern={pattern}, "
                 f"type={type(pattern)}"
             )
+
+        if isinstance(pattern, str):
+            pattern = re.compile(pattern)
 
         globals()[cast.__name__] = cast
         self.regex_types[label] = (cast, pattern)

--- a/sanic_routing/router.py
+++ b/sanic_routing/router.py
@@ -2,7 +2,6 @@ import ast
 import sys
 import typing as t
 from abc import ABC, abstractmethod
-from re import Pattern
 from types import SimpleNamespace
 from warnings import warn
 
@@ -257,7 +256,7 @@ class BaseRouter(ABC):
         :type cast: t.Callable[[str], t.Any]
         :param pattern: A regular expression that could also match the path
             segment
-        :type pattern: Pattern
+        :type pattern: str
         """
         if not isinstance(label, str):
             raise InvalidUsage(

--- a/sanic_routing/router.py
+++ b/sanic_routing/router.py
@@ -239,7 +239,7 @@ class BaseRouter(ABC):
         return route
 
     def register_pattern(
-        self, label: str, cast: t.Callable[[str], t.Any], pattern: Pattern
+        self, label: str, cast: t.Callable[[str], t.Any], pattern: str
     ):
         """
         Add a custom parameter type to the router. The cast shoud raise a

--- a/tests/test_custom_param_types.py
+++ b/tests/test_custom_param_types.py
@@ -54,6 +54,22 @@ def test_does_not_cast(handler):
         router.get("/notfound", "BASE")
 
 
+def test_works_with_patterns(handler):
+    router = Router()
+    router.register_pattern(
+        "ipv4",
+        ipaddress.ip_address,
+        re.compile(r"^(?:(?:25[0-5]|2[0-4][0-9]|"
+                   r"[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|"
+                   r"2[0-4][0-9]|[01]?[0-9][0-9]?)$"))
+
+    router.add("/<ip:ipv4>", handler)
+    router.finalize()
+
+    with pytest.raises(NotFound):
+        router.get("/notfound", "BASE")
+
+
 def test_bad_registries():
     router = Router()
 
@@ -65,6 +81,3 @@ def test_bad_registries():
 
     with pytest.raises(InvalidUsage):
         router.register_pattern("ipv4", ipaddress.ip_address, None)
-
-    with pytest.raises(InvalidUsage):
-        router.register_pattern("regex", ipaddress.ip_address, re.compile(".*"))

--- a/tests/test_custom_param_types.py
+++ b/tests/test_custom_param_types.py
@@ -1,4 +1,5 @@
 import ipaddress
+import re
 
 import pytest
 
@@ -64,3 +65,6 @@ def test_bad_registries():
 
     with pytest.raises(InvalidUsage):
         router.register_pattern("ipv4", ipaddress.ip_address, None)
+
+    with pytest.raises(InvalidUsage):
+        router.register_pattern("regex", ipaddress.ip_address, re.compile(".*"))

--- a/tests/test_custom_param_types.py
+++ b/tests/test_custom_param_types.py
@@ -59,9 +59,12 @@ def test_works_with_patterns(handler):
     router.register_pattern(
         "ipv4",
         ipaddress.ip_address,
-        re.compile(r"^(?:(?:25[0-5]|2[0-4][0-9]|"
-                   r"[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|"
-                   r"2[0-4][0-9]|[01]?[0-9][0-9]?)$"))
+        re.compile(
+            r"^(?:(?:25[0-5]|2[0-4][0-9]|"
+            r"[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|"
+            r"2[0-4][0-9]|[01]?[0-9][0-9]?)$"
+        ),
+    )
 
     router.add("/<ip:ipv4>", handler)
     router.finalize()

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import date
 
 import pytest
+
 from sanic_routing import BaseRouter
 from sanic_routing.exceptions import NoMethod, NotFound, RouteExists
 


### PR DESCRIPTION
Previously the `register_pattern` method had a type declaration of `Pattern` for the `pattern` argument, but the instance checker would raise an error if the pattern was not a string.

This commit changes the type declaration to accept `str` rather than Pattern. Changing the type annotation was chosen as it was the least disruptive to the current behaviour of the library.

A small test was added to check that this function does not accept compiled regex statements.

Fixes #56 