### PR TITLE
[BREAKING] Only match non-empty string

### DIFF
--- a/sanic_routing/patterns.py
+++ b/sanic_routing/patterns.py
@@ -19,6 +19,12 @@ def slug(param: str) -> str:
     return param
 
 
+def nonemptystr(param: str) -> str:
+    if not param:
+        raise ValueError(f"Value {param} is an empty string")
+    return param
+
+
 REGEX_PARAM_NAME = re.compile(r"^<([a-zA-Z_][a-zA-Z0-9_]*)(?::(.*))?>$")
 
 # Predefined path parameter types. The value is a tuple consisteing of a
@@ -30,7 +36,8 @@ REGEX_PARAM_NAME = re.compile(r"^<([a-zA-Z_][a-zA-Z0-9_]*)(?::(.*))?>$")
 # The regular expression is generally NOT used. Unless the path is forced
 # to use regex patterns.
 REGEX_TYPES = {
-    "str": (str, re.compile(r"^[^/]+$")),
+    "strorempty": (str, re.compile(r"^[^/]*$")),
+    "str": (nonemptystr, re.compile(r"^[^/]+$")),
     "slug": (slug, re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")),
     "alpha": (alpha, re.compile(r"^[A-Za-z]+$")),
     "path": (str, re.compile(r"^[^/]?.*?$")),

--- a/sanic_routing/router.py
+++ b/sanic_routing/router.py
@@ -27,7 +27,7 @@ import re  # noqa  isort:skip
 from datetime import datetime  # noqa  isort:skip
 from urllib.parse import unquote  # noqa  isort:skip
 from uuid import UUID  # noqa  isort:skip
-from .patterns import parse_date, alpha, slug  # noqa  isort:skip
+from .patterns import parse_date, alpha, slug, nonemptystr  # noqa  isort:skip
 
 
 class BaseRouter(ABC):


### PR DESCRIPTION
Stemming from the conversation here: https://github.com/sanic-org/sanic-guide/issues/92

This is a **BREAKING** change.

This this change, these will **NOT** match on an empty string.

```python
router.add("/<foo>", ...)
router.add("/<foo:str>", ...)
```

This also adds `<foo:strorempty>` to allow for matching empty str patterns.