### PR TITLE
Don't try empty path if '/' was not found.

### DIFF
--- a/sanic_routing/router.py
+++ b/sanic_routing/router.py
@@ -89,7 +89,7 @@ class BaseRouter(ABC):
         except (NotFound, NoMethod) as e:
             # If we did not find the route, we might need to try routing one
             # more time to handle strict_slashes
-            if path.endswith(self.delimiter):
+            if len(path) > 1 and path.endswith(self.delimiter):
                 return self.resolve(
                     path=path[:-1],
                     method=method,


### PR DESCRIPTION
`Requested URL  not found` when accessing `/` without `strict_slashes` enabled. I did not check whether there is a similar problem with subdirectories too. The URL requested by the client should be shown, not the one with a slash removed.

The message is also fixable in sanic/router.py:42 by using `path` instead of `e.path`.